### PR TITLE
Bugfix implicit joins 4.1

### DIFF
--- a/lib/declarative_authorization/obligation_scope.rb
+++ b/lib/declarative_authorization/obligation_scope.rb
@@ -60,7 +60,7 @@ module Authorization
         self.klass.scoped(@finder_options)
       else
         # TODO Refactor this.  There is certainly a better way.
-        self.klass.joins(@finder_options[:joins]).includes(@finder_options[:include]).where(@finder_options[:conditions])
+        self.klass.joins(@finder_options[:joins]).includes(@finder_options[:include]).where(@finder_options[:conditions]).references(@finder_options[:include])
       end
     end
 

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -774,13 +774,14 @@ class NamedScopeModelTest < Test::Unit::TestCase
     TestAttr.delete_all
   end
 
-  def test_with_pickle
+  def test_with_multiple_conditions
     reader = Authorization::Reader::DSLReader.new
     reader.parse %{
       authorization do
         role :test_role do
           has_permission_on :test_attrs, :to => :read do
             if_attribute :test_model => {:content => is { "pickle" } }
+            if_attribute :test_model => {:content => is { "hotdog" } }
           end
         end
       end


### PR DESCRIPTION
Adding test to cover multiple conditions with nested attributes. Rails 4.1 removes implicit join references so this must be explicitly done in the generated query.